### PR TITLE
vary transaction gas and amount around suggested values

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,18 @@ flags:
 chainload --help
 
 Usage of chainload:
+  -amount uint
+    	tx amount (approximate) (default 10)
   -dur duration
     	duration to run - omit for unlimited
   -gas uint
-    	gas (default 200000)
+    	gas (approximate) (default 200000)
   -id uint
     	id (default 1234)
   -pass string
     	passphrase to unlock accounts (default "#go@chain42")
   -pprof string
-        pprof addr (default ":6060")
+    	pprof addr (default ":6060")
   -senders int
     	total number of concurrent senders/accounts - defaults to 1/10 of tps
   -tps int
@@ -56,7 +58,8 @@ be pre-existing. One seeder is started per url, to continually re-claim
 funds from other accounts, and to seed funds to senders. Senders may
 reuse pre-existing accounts or create new ones. Senders continually send
 txs to a set of receivers, while periodically cycling out the sender and
-receiver addresses.
+receiver addresses. The `gas` and `amount` of each transaction varies
+randomly from the suggested approximate values.
 
 ## Problems
 

--- a/backoff.go
+++ b/backoff.go
@@ -26,7 +26,7 @@ func (b *backOff) doTimed(ctx context.Context, timer metrics.Timer, fn func() er
 		if ctx.Err() != nil {
 			return false
 		}
-		if wait = jitter(2*wait, 10); wait > b.maxWait {
+		if wait = jitterDur(2*wait, 10); wait > b.maxWait {
 			wait = b.maxWait
 		}
 		log.Printf("Pausing: %s attempt=%d pause=%s\n", err, errs, wait)
@@ -42,11 +42,20 @@ func (b *backOff) doTimed(ctx context.Context, timer metrics.Timer, fn func() er
 	return true
 }
 
-// jitter returns d with random jitter +/- up to limit percent.
-func jitter(d time.Duration, limit int) time.Duration {
+// jitterDur returns d with random jitterDur +/- up to limit percent, rounded to seconds.
+func jitterDur(d time.Duration, limit int) time.Duration {
 	j := time.Duration(int(d) * rand.Intn(limit) / 100)
 	if rand.Intn(2) == 0 {
 		j = -j
 	}
 	return (d + j).Round(time.Second)
+}
+
+// jitter returns i with random jitterDur +/- up to limit percent.
+func jitter(i uint64, limit int) uint64 {
+	j := i * uint64(rand.Intn(limit)) / 100
+	if rand.Intn(2) == 0 {
+		j = -j
+	}
+	return i + j
 }

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ type Config struct {
 	dur       time.Duration
 	pass      string
 	gas       uint64
-	amount    *big.Int
+	amount    uint64
 	pprofAddr string
 	verbose   bool
 }
@@ -43,8 +43,8 @@ func init() {
 	flag.IntVar(&config.senders, "senders", 0, "total number of concurrent senders/accounts - defaults to 1/10 of tps")
 	flag.DurationVar(&config.dur, "dur", 0, "duration to run - omit for unlimited")
 	flag.StringVar(&config.pass, "pass", "#go@chain42", "passphrase to unlock accounts")
-	flag.Uint64Var(&config.gas, "gas", 200000, "gas")
-	config.amount = new(big.Int).SetUint64(1)
+	flag.Uint64Var(&config.gas, "gas", 200000, "gas (approximate)")
+	flag.Uint64Var(&config.amount, "amount", 10, "tx amount (approximate)")
 	flag.StringVar(&config.pprofAddr, "pprof", ":6060", "pprof addr")
 	flag.BoolVar(&config.verbose, "v", false, "verbose logging")
 }

--- a/node.go
+++ b/node.go
@@ -33,13 +33,14 @@ func (n *Node) refund(ctx context.Context, acct accounts.Account, nonce uint64, 
 	}
 	suggestGasPriceTimer.UpdateSince(t)
 
+	gas := jitter(config.gas, 10)
 	var amount big.Int
-	amount.Mul(new(big.Int).SetUint64(config.gas), gasPrice)
+	amount.Mul(new(big.Int).SetUint64(gas), gasPrice)
 	amount.Sub(bal, &amount)
 	if amount.Cmp(new(big.Int)) < 1 {
 		return 0, nil
 	}
-	tx := types.NewTransaction(nonce, seed, &amount, config.gas, gasPrice, nil)
+	tx := types.NewTransaction(nonce, seed, &amount, gas, gasPrice, nil)
 
 	t = time.Now()
 	tx, err = n.SignTx(acct, tx)

--- a/sender.go
+++ b/sender.go
@@ -220,8 +220,8 @@ func (s *Sender) send(ctx context.Context) {
 
 	gasPrice := new(big.Int).Div(s.gasPrice, new(big.Int).SetInt64(rand.Int63n(5)+5))
 	gasPrice.Add(s.gasPrice, gasPrice)
-
-	tx := types.NewTransaction(s.nonce, recv, config.amount, config.gas, gasPrice, nil)
+	amount := new(big.Int).SetUint64(jitter(config.amount, 90))
+	tx := types.NewTransaction(s.nonce, recv, amount, jitter(config.gas, 10), gasPrice, nil)
 	t := time.Now()
 	tx, err := s.AccountStore.SignTx(*s.acct, tx)
 	if err != nil {
@@ -262,7 +262,7 @@ func (s *Sender) send(ctx context.Context) {
 		return
 	} else if msg == "transaction pool limit reached" {
 		print = true
-		wait = jitter(time.Minute, 80)
+		wait = jitterDur(time.Minute, 80)
 	} else if knownTxErr(msg) || lowFundsErr(msg) {
 		log.Printf("Abandoning account\t%s err=%s\n", s, msg)
 		s.transition(senderAssignState)
@@ -271,7 +271,7 @@ func (s *Sender) send(ctx context.Context) {
 		return
 	} else {
 		print = true
-		wait = jitter(30*time.Second, 50)
+		wait = jitterDur(30*time.Second, 50)
 	}
 	if wait == 0 && (print || config.verbose) {
 		log.Printf("Failed to send\t%s err=%q\n", s, err)


### PR DESCRIPTION
This PR adds some variance to the gas and amount of each transaction, providing a more realistic load. It also adds an `-amount` flag and updates the docs.